### PR TITLE
Add SnapDeploy to Full-Stack Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@
 | **[IBM Cloud](https://cloud.ibm.com/)** | ✅ **Lite Plan** | No expiry | 256MB Cloud Foundry App | ✅ No |
 | **[Railway](https://railway.app/)** | ✅ **$5 Credit (Trial)** | Usage-based | Simple UX, good for testing | ✅ No |
 | **[Hostim.dev](https://hostim.dev/)** | ⏱️ **5-day App Trial** | No sleep | Docker apps + always-free managed DBs | ✅ Yes |
+| **[SnapDeploy](https://snapdeploy.dev/)** | ✅ **4 Containers, 512 MB** | Sleeps after 15m idle | Auto-detect & deploy any Dockerfile/framework | ✅ Yes |
 
 </div>
 


### PR DESCRIPTION
Adding [SnapDeploy](https://snapdeploy.dev) to the Full-Stack Platforms section.

**Free tier highlights:**
- 4 containers, 512 MB RAM, 0.25 vCPU each, no time limits, no credit card required
- Auto-sleep after 15 min idle, auto-wake on traffic (~60s cold start)
- Auto-detects Node.js, Python, Java, Go, PHP, Ruby, .NET, or any Dockerfile
- GitHub auto-deploy via GitHub App integration

**Paid tier:**
- Always-On from $12/mo per container (no sleep)

Website: https://snapdeploy.dev
GitHub Marketplace: https://github.com/marketplace/snapdeploy-app